### PR TITLE
Fix for windows with number >9

### DIFF
--- a/dswitcher
+++ b/dswitcher
@@ -10,6 +10,6 @@ if [[ $height -gt 30 ]]
 	else heightfit=$height
 fi
 
-num=$(wmctrl -l | sed 's/  / /' | cut -d " " -f 4- | nl -n ln | sed 's/     / - /' | cut -c 1-4,6- | dmenu -b -i -p "$date" -l $heightfit | cut -c -1)
+num=$(wmctrl -l | sed 's/  / /' | cut -d " " -f 4- | nl -w 3 -n rn | sed -r 's/^([ 0-9]+)[ \t]*(.*)$/\1 - \2/' | dmenu -b -i -p "$date" -l $heightfit | cut -d '-' -f -1)
 [[ -z "$num" ]] && exit
 wmctrl -l | sed -n "$num p" | cut -c -10 | xargs wmctrl -i -a


### PR DESCRIPTION
Now should format the menu nicely for windows numbered up to 999 (previously broke at 10)
Now also reads the output of dmenu differently, reading up to the first "-" rather than reading only the first character (previously also broke at 10)
